### PR TITLE
Export Bug fixes

### DIFF
--- a/TemplateApp/Services/CredentialService.cs
+++ b/TemplateApp/Services/CredentialService.cs
@@ -74,9 +74,9 @@ namespace Protecc.Services
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    CredentialList.Clear();
                     foreach (var i in Vault.RetrieveAll())
                     {
+                        i.RetrievePassword();
                         Accounts.Add(new Account() { 
                             Name = i.UserName,
                             Resource = i.Resource,


### PR DESCRIPTION
Addresses two issues from #31 
1. When exporting the keys disappear from the UI. 
   - This happened because the credentials list that was bound to the UI was being cleared. I don't think that needs to be cleared since the data is only being written out. Alternatively, and additional `Add()` could be included in the foreach loop as well.
2. When exporting, the password is not being serialized
   - This was happening because `RetrievePassword()` needs to be called to populate the password field prior to accessing it. See https://docs.microsoft.com/en-us/uwp/api/windows.security.credentials.passwordcredential.retrievepassword?view=winrt-22621#windows-security-credentials-passwordcredential-retrievepassword
