### PR TITLE
fix: correctly show as a C# Project in GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,7 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# correctly show as a C# Project in GitHub
+*.html linguist-detectable=false
+*.cs linguist-detectable=true


### PR DESCRIPTION
previously chowing as a HTML project, due to a higher number of HTML source lines