### PR TITLE
Feature: Copy code to clipboard by double clicking AccountControl

### DIFF
--- a/TemplateApp/Controls/AccountControl.xaml
+++ b/TemplateApp/Controls/AccountControl.xaml
@@ -17,7 +17,7 @@
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
     mc:Ignorable="d">
-    <StackPanel Width="300" Loaded="Content_Loaded" Unloaded="Content_Unloaded">
+    <StackPanel Width="300" Loaded="Content_Loaded" Unloaded="Content_Unloaded" DoubleTapped="Content_DoubleTapped">
         <Grid CornerRadius="8" Padding="12, 12, 12, 0" Margin="0, 0, 0, 8" Height="80" BorderThickness="1" Canvas.ZIndex="3">
             <TextBlock MaxWidth="210" Opacity="0.7" TextTrimming="CharacterEllipsis" FontSize="20" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="1" Text="{x:Bind AccountVaultItem.Name, Mode=OneWay}"/>
             <Grid HorizontalAlignment="Left" VerticalAlignment="Bottom" Width="200" Height="80" Margin="0, 0, 0, -20" >

--- a/TemplateApp/Controls/AccountControl.xaml.cs
+++ b/TemplateApp/Controls/AccountControl.xaml.cs
@@ -103,10 +103,15 @@ namespace Protecc.Controls
                 dataPackage.SetText(TOTP.Code.Replace(" ", ""));
                 Clipboard.SetContent(dataPackage);
                 CopyIcon.Symbol = Fluent.Icons.FluentSymbol.Checkmark20;
+                // Show notification
+                InAppNotificationComponent.Show("Code copied to clipboard!", 3000);
             }
             catch
             {
                 CopyIcon.Symbol = Fluent.Icons.FluentSymbol.ErrorCircle20;
+                // Inform user about error
+                InAppNotificationComponent.Show("An error occurred while copying to clipboard.", 3000);
+
             }
             await Task.Delay(2000);
             CopyIcon.Symbol = Fluent.Icons.FluentSymbol.Copy20;

--- a/TemplateApp/Controls/AccountControl.xaml.cs
+++ b/TemplateApp/Controls/AccountControl.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Protecc.Classes;
+﻿using Microsoft.Toolkit.Uwp.Notifications;
+using Protecc.Classes;
 using Protecc.Helpers;
 using Protecc.Services;
 using System;
@@ -110,5 +111,28 @@ namespace Protecc.Controls
         }
 
         //private void Content_Loaded(object sender, RoutedEventArgs e) => TOTP = new TOTPHelper(CodeBlock, Progress, AccountVaultItem);
+
+        /// <summary>
+        /// Copies displayed code to clipboard and displays Windows notification.
+        /// </summary>
+        private void Content_DoubleTapped(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // Remove spaces and copy to clipboard
+                var content = new DataPackage();
+                content.RequestedOperation = DataPackageOperation.Copy;
+                content.SetText(TOTP.Code.Replace(" ", ""));
+                Clipboard.SetContent(content);
+
+                // Show notification
+                new ToastContentBuilder().AddText("Code copied to clipboard!").Show();
+            }
+            catch
+            {
+                // Inform user about error
+                new ToastContentBuilder().AddText("An error occurred while copying to clipboard.").Show();
+            }
+        }
     }
 }

--- a/TemplateApp/Controls/AccountControl.xaml.cs
+++ b/TemplateApp/Controls/AccountControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Toolkit.Uwp.Notifications;
+﻿using Microsoft.Toolkit.Uwp.UI.Controls;
 using Protecc.Classes;
 using Protecc.Helpers;
 using Protecc.Services;
@@ -37,13 +37,25 @@ namespace Protecc.Controls
         public VaultItem AccountVaultItem
         {
             get { return (VaultItem)GetValue(AccountVaultItemProperty); }
-            set { 
+            set
+            {
                 SetValue(AccountVaultItemProperty, value);
                 TOTP = new TOTPHelper(AccountVaultItem);
             }
         }
         public static readonly DependencyProperty AccountVaultItemProperty =
                    DependencyProperty.Register("AccountVaultItem", typeof(VaultItem), typeof(AccountControl), null);
+
+        public InAppNotification InAppNotificationComponent
+        {
+            get { return (InAppNotification)GetValue(InAppNotificationComponentProperty); }
+            set
+            {
+                SetValue(InAppNotificationComponentProperty, value);
+            }
+        }
+        public static readonly DependencyProperty InAppNotificationComponentProperty =
+                   DependencyProperty.Register("InAppNotificationComponent", typeof(InAppNotification), typeof(AccountControl), null);
 
         public AccountControl()
         {
@@ -126,12 +138,12 @@ namespace Protecc.Controls
                 Clipboard.SetContent(content);
 
                 // Show notification
-                new ToastContentBuilder().AddText("Code copied to clipboard!").Show();
+                InAppNotificationComponent.Show("Code copied to clipboard!", 3000);
             }
             catch
             {
                 // Inform user about error
-                new ToastContentBuilder().AddText("An error occurred while copying to clipboard.").Show();
+                InAppNotificationComponent.Show("An error occurred while copying to clipboard.", 3000);
             }
         }
     }

--- a/TemplateApp/MainPage.xaml
+++ b/TemplateApp/MainPage.xaml
@@ -83,7 +83,7 @@
             <GridView x:Name="AccountsView" ItemContainerStyle="{ThemeResource CardContainer}" SelectionChanged="AccountsView_SelectionChanged" ItemsSource="{x:Bind Services:CredentialService.CredentialList, Mode=OneWay}" SelectionMode="Single" VerticalAlignment="Top" Margin="-8, 86, -50, 0" HorizontalAlignment="Left">
                 <GridView.ItemTemplate>
                     <DataTemplate x:DataType="Classes:VaultItem">
-                        <controls:AccountControl AccountVaultItem="{x:Bind }"/>
+                        <controls:AccountControl AccountVaultItem="{x:Bind }" InAppNotificationComponent="{Binding ElementName=InAppNotificationComponent}"/>
                     </DataTemplate>
                 </GridView.ItemTemplate>
                 <GridView.ItemContainerTransitions>
@@ -103,5 +103,6 @@
                 </Grid.Background>
             </Grid>
         </Grid>
+        <toolkit:InAppNotification Name="InAppNotificationComponent" />
     </Grid>
 </Page>

--- a/TemplateApp/Protecc.csproj
+++ b/TemplateApp/Protecc.csproj
@@ -286,6 +286,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.11</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
+      <Version>7.1.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
       <Version>7.1.2</Version>
     </PackageReference>

--- a/TemplateApp/Protecc.csproj
+++ b/TemplateApp/Protecc.csproj
@@ -286,9 +286,6 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.11</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.1.2</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
       <Version>7.1.2</Version>
     </PackageReference>


### PR DESCRIPTION
# Description
Solves issue #39.
User can double click any part of `AccountControl` to copy code to clipboard. A Windows notification will be shown that informs user if the operation was successful or if an error occurred.
# Changes
- Added `DoubleTapped` event handler to `AccountControl` that copies code to clipboard and then shows a notification about the action;
- Added `Microsoft.Toolkit.Uwp.Notifications` NuGet package to `Protecc` project that is used to construct and show Windows notifications.